### PR TITLE
Missing folder on `open` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ sbt
 ## Preview
 
 ```bash
-open target/paradox/site/home.html
+open target/paradox/site/main/home.html
 ```
 
 ## Reference


### PR DESCRIPTION
Locally I also needed to add the `main` folder on the path.