### PR TITLE
Add example nginx controller

### DIFF
--- a/src/main/paradox/files/example-nginx-controller.yaml
+++ b/src/main/paradox/files/example-nginx-controller.yaml
@@ -1,0 +1,108 @@
+---
+# This file contains an example Ingress Controller that can be used on Kubernetes
+# in environments that do not provide one.
+#
+# It is not production grade and support is not covered by a Lightbend Subscription.
+# For a production grade Ingress Controller, consult your Kubernetes provider.
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-ingress-controller
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: nginx-ingress-lb
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: nginx-ingress-controller
+        image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+        readinessProbe:
+          httpGet:
+            path: "/healthz"
+            port: 18080
+            scheme: HTTP
+        livenessProbe:
+          httpGet:
+            path: "/healthz"
+            port: 18080
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        args:
+        - "/nginx-ingress-controller"
+        - "--default-backend-service=$(POD_NAMESPACE)/nginx-default-backend"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 80
+        - containerPort: 443
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-ingress
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    name: http
+  - port: 443
+    name: https
+  selector:
+    k8s-app: nginx-ingress-lb
+---
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-default-backend
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx-default-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: nginx-default-backend
+        image: gcr.io/google_containers/defaultbackend:1.0
+        livenessProbe:
+          httpGet:
+            path: "/healthz"
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-default-backend
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    app: nginx-default-backend


### PR DESCRIPTION
To be used with some guides (e.g. IBM's Chirper one that's in the works) in environments that don't provide their own (e.g. IBM's free tier cloud). This way, the guide can simply say something like:

#### Add Ingress Controller

```bash
kubectl apply -f https://developer.lightbend.com/docs/lightbend-orchestration-kubernetes/latest/files/example-nginx-controller.yml
```