### PR TITLE
Update cli-installation.md

### DIFF
--- a/src/main/paradox/cli-installation.md
+++ b/src/main/paradox/cli-installation.md
@@ -33,6 +33,7 @@ wget -qO - https://downloads.lightbend.com/rp/keys/bintray-debian | \
     sudo apt-key add - && \
     echo "deb https://dl.bintray.com/lightbend/deb $(lsb_release -cs) main" | \
     sudo tee /etc/apt/sources.list.d/lightbend.list && \
+    sudo apt-get install apt-transport-https -y && \
     sudo apt-get update && \
     sudo apt-get install reactive-cli
 ```


### PR DESCRIPTION
Installed failed on fresh Debian 9. Needed apt-transport-https installed first. Adding it to the doc.