### PR TITLE
Correct misspelt platform-tooling endpoint names

### DIFF
--- a/src/main/paradox/features.md
+++ b/src/main/paradox/features.md
@@ -231,7 +231,7 @@ Windows
 
 A status facility is provided by the tooling. When enabled, an additional route is added to the Akka Management HTTP
 server and the appropriate health and readiness checks are defined. By default, this route responds to
-requests to `/platform-tooling/health` and `/platform-tooling/readiness`.
+requests to `/platform-tooling/healthy` and `/platform-tooling/ready`.
 
 #### Configuration
 


### PR DESCRIPTION
Docs are slightly out of sync with the code vis-a-vis endpoint names, so correct the spelling.

Fixes #52.