### PR TITLE
Update reference to the Lightbend helm-charts repo

### DIFF
--- a/src/main/paradox/setup/reactive-sandbox.md
+++ b/src/main/paradox/setup/reactive-sandbox.md
@@ -10,7 +10,7 @@ behavior.
 ```bash
 # Install Helm and add the Lightbend repository
 helm init
-helm repo add lightbend-helm-charts https://lightbend.github.io/helm-charts
+helm repo add lightbend-helm-charts https://repo.lightbend.com/helm-charts
 helm update
 
 # Install the reactive-sandbox


### PR DESCRIPTION
The default location for the Lightbend helm-charts repo has moved to https://repo.lightbend.com/helm-charts and the old location (https://lightbend.github.io/helm-charts) is deprecated (and may go away at some point). This change updates the reference in the reactive-sandbox documentation.