### PR TITLE
Add missing `rp` prefixes introduced in 1.7.0

### DIFF
--- a/src/main/paradox/getting-started/sbt-play-minikube.md
+++ b/src/main/paradox/getting-started/sbt-play-minikube.md
@@ -113,7 +113,7 @@ In the sbt shell type the following:
 
 ```
 compile
-deploy minikube
+rpDeploy minikube
 ```
 
 If successful you should see an output like the following:

--- a/src/main/paradox/kubernetes-development.md
+++ b/src/main/paradox/kubernetes-development.md
@@ -1,6 +1,6 @@
 # Kubernetes Development
 
-[sbt-reactive-app](https://github.com/lightbend/sbt-reactive-app) includes an sbt task, `deploy minikube`, that can be
+[sbt-reactive-app](https://github.com/lightbend/sbt-reactive-app) includes an sbt task, `rpDeploy minikube`, that can be
 used to simplify running your application in your local Minikube. This is especially useful as a development tool
 to get a quick feedback on modifications as you develop your applications.
 
@@ -17,7 +17,7 @@ development-grade (i.e. don't use it in production) installations of Cassandra, 
 
 ### Getting Started
 
-To use this feature, launch the sbt console and type `deploy minikube`. This will run the task on all aggregated
+To use this feature, launch the sbt console and type `rpDeploy minikube`. This will run the task on all aggregated
 subprojects. The task will install Helm and the Reactive Sandbox (if required) and install (or replace) all of the
 applications. You can also run the task on a specific subproject if you only wish to deploy that application.
 

--- a/src/main/paradox/setup/project-setup.md
+++ b/src/main/paradox/setup/project-setup.md
@@ -74,7 +74,7 @@ Later in the documentation we'll cover how you can then generate Kubernetes and 
 
 > The following feature is currently only available for Kubernetes.
 
-Lightbend Orchestration provides an sbt task, `deploy minikube`, that makes it easy for developers to deploy their application to their own local Kubernetes cluster.
+Lightbend Orchestration provides an sbt task, `rpDeploy minikube`, that makes it easy for developers to deploy their application to their own local Kubernetes cluster.
 
 The following command will build and deploy all of your services into your local Kubernetes cluster. You'll need to ensure that the following software is installed:
 

--- a/src/main/paradox/setup/reactive-sandbox.md
+++ b/src/main/paradox/setup/reactive-sandbox.md
@@ -3,8 +3,8 @@
 Lightbend Orchestration is integrated with Lightbend's [Reactive Sandbox](https://github.com/lightbend/reactive-sandbox)
 which provides development-grade (i.e. don't use it in production) installations of Cassandra, Elasticsearch, Kafka, and ZooKeeper.
 
-You can install the sandbox with the commands below. If you use the `deploy minikube` sbt task, it will automatically
-install it for you if required. You can also use the setting `deployMinikubeEnableReactiveSandbox` to adjust this
+You can install the sandbox with the commands below. If you use the `rpDeploy minikube` sbt task, it will automatically
+install it for you if required. You can also use the setting `rpDeployMinikubeEnableReactiveSandbox` to adjust this
 behavior.
 
 ```bash


### PR DESCRIPTION
With version 1.7.0, `rp` prefix was added to tasks (added in doc with #75 )
However, some prefixes are still missing. This PR adds the missing prefixes.